### PR TITLE
Hotfix type errors in blog page & layout

### DIFF
--- a/portfolio/app/blog/[postid]/layout.tsx
+++ b/portfolio/app/blog/[postid]/layout.tsx
@@ -5,12 +5,8 @@ import {Metadata} from "next";
 import {JSDOM} from "jsdom";
 import PostData from "./posttype"
 
-type Props = {
-  params: { postid: string };
-  searchParams: { [key: string]: string | string[] | undefined };
-};
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
+export async function generateMetadata({ params }: { params: {postid: string} }): Promise<Metadata> {
   if (!(/^\d+$/.test(params.postid))) {
     return {
       title: "Invalid PostID",

--- a/portfolio/app/blog/[postid]/page.tsx
+++ b/portfolio/app/blog/[postid]/page.tsx
@@ -32,8 +32,8 @@ const contentTitleFont = Nanum_Gothic({
   subsets: ["latin"]
 })
 
-function stylish({fontStyle, fontFamily, fontWeight}: {fontStyle: string, fontFamily: string, fontWeight: string}) {
-  return `font-style:${fontStyle};font-family:${fontFamily};font-weight:${fontWeight};`
+function stylish({fontStyle, fontFamily, fontWeight}: {fontFamily: string, fontWeight?: number, fontStyle?: string }) {
+  return `font-family:${fontFamily};${fontStyle ? "font-style:"+fontStyle+";" : ""}${fontWeight ? "font-weight:"+fontWeight+";" : ""}`
 }
 
 export default function PostView({params}: {params: {postid: string}}) {


### PR DESCRIPTION
+ Solved stylish parameter type error
+ Solved "type Props is not valid" in layout's generateMetadata function